### PR TITLE
Bump Jiralert to version 1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated `Jiralert` to version 1.2.
+- Updated `Jiralert` to version 1.2. This version adds the auto-resolve feature.
 
 ## [0.0.2] - 2022-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated `Jiralert` to version 1.2.
+
 ## [0.0.2] - 2022-05-16
 
 ### Changed

--- a/helm/jiralert/values.yaml
+++ b/helm/jiralert/values.yaml
@@ -8,7 +8,7 @@ project:
 image:
   registry: docker.io
   name: giantswarm/jiralert
-  tag: 1.1
+  tag: 1.2
   pullPolicy: IfNotPresent
 
 init:


### PR DESCRIPTION
I will be testing Jiralert 1.2. 

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
