### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [0.1.2] - 2023-10-31
 
 ### Changed

--- a/helm/jiralert/values.yaml
+++ b/helm/jiralert/values.yaml
@@ -11,13 +11,13 @@ project:
   commit: "[[ .SHA ]]"
 
 image:
-  registry: docker.io
+  registry: gsoci.azurecr.io
   name: giantswarm/jiralert
   tag: 1.2-extra-functions
   pullPolicy: IfNotPresent
 
 init:
-  registry: docker.io
+  registry: gsoci.azurecr.io
   name: giantswarm/busybox
   tag: 1.34.1
 
@@ -49,7 +49,7 @@ securityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop:
-    - ALL
+      - ALL
   privileged: false
   runAsNonRoot: true
   readOnlyRootFilesystem: true


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
